### PR TITLE
Fix an off-by-one error in key config menu

### DIFF
--- a/src/avp/win95/frontend/avp_menus.c
+++ b/src/avp/win95/frontend/avp_menus.c
@@ -2270,7 +2270,7 @@ static void ActUponUsersInput(void)
 			signed int key,selectedKey=-1;
 
 			// see if a valid key has been pressed
-			for (key = 0 ; key <= MAX_NUMBER_OF_INPUT_KEYS ; key++)
+			for (key = 0 ; key < MAX_NUMBER_OF_INPUT_KEYS ; key++)
 			{
 				if (!(key == KEY_ESCAPE) &&
 //					!(key >= KEY_F1 && key <= KEY_F12) &&


### PR DESCRIPTION
When checking for user input in the keyboard config menu, a read past the end of the `DebouncedKeyboardInput` array returned a nonzero value on some systems, which prevented setting a valid binding. This fixes #1.