### PR TITLE
Fix crash in DrawMainMenusBackdrop

### DIFF
--- a/src/avp/win95/frontend/avp_menus.c
+++ b/src/avp/win95/frontend/avp_menus.c
@@ -4924,31 +4924,6 @@ extern void DrawMainMenusBackdrop(void)
 	{
 		DrawAvPMenuGfx(AVPMENUGFX_BACKDROP,0,0,ONE_FIXED+1,AVPMENUFORMAT_LEFTJUSTIFIED);
 	}
-	else
-	{
-		extern unsigned char *ScreenBuffer;
-		unsigned int *screenPtr = (unsigned int*)ScreenBuffer;
-		int i;	  
-
-		i = ScreenDescriptorBlock.SDB_Width * 60 /2;
-		do
-		{
-			*screenPtr++=0; 
-		}
-		while(--i);
-
-		screenPtr+=ScreenDescriptorBlock.SDB_Width * 360/2;
-
-		i = ScreenDescriptorBlock.SDB_Width * 60 /2;
-		do
-		{
-			*screenPtr++=0; 
-		}
-		while(--i);
-	}
-
-
-
 	#else
 	extern DDPIXELFORMAT DisplayPixelFormat;
 	extern unsigned char *ScreenBuffer;


### PR DESCRIPTION
Remove some obsolete and dysfunctional code that was triggered when binked menu background was implemented. As far as I can tell this code was left over since before the SDL port, but was never run because `PlayMenuBackgroundBink` wasn’t implemented.

I believe this fixes #2. Not sure why it only seems to crash on some systems.